### PR TITLE
Stop the LICENSE snapshot rotting every new year

### DIFF
--- a/__tests__/__snapshots__/app.js.snap
+++ b/__tests__/__snapshots__/app.js.snap
@@ -99,7 +99,7 @@ exports[`creates .prettierrc.json 1`] = `
 exports[`creates LICENSE 1`] = `
 "MIT License
 
-Copyright (c) 2024 John Smith <john.smith@js.com>
+Copyright (c) <year> John Smith <john.smith@js.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -20,6 +20,13 @@ const readFile = (file) => {
   return path.extname(file) === '.json' ? JSON.parse(data) : data
 }
 
+// The LICENSE template stamps the current year, so a snapshot holding it
+// verbatim goes stale on 1 January and stays stale until someone notices.
+const normaliseYear = (data) =>
+  typeof data === 'string'
+    ? data.replace(/Copyright \(c\) \d{4}/, 'Copyright (c) <year>')
+    : data
+
 const emailMock = jest.fn().mockResolvedValue('mock.user@mock.com')
 const nameMock = jest.fn().mockResolvedValue('Mock Name')
 const githubUsernameMock = jest.fn().mockResolvedValue('mockgithubusername')
@@ -67,6 +74,6 @@ test.each(getFiles())('creates %s', (file) => {
         : {}),
     })
   } else {
-    expect(readFile(file)).toMatchSnapshot()
+    expect(normaliseYear(readFile(file))).toMatchSnapshot()
   }
 })


### PR DESCRIPTION
The LICENSE template stamps `new Date().getFullYear()`, and the snapshot held the generated year verbatim. It captured 2024, so the suite went red on 1 January 2025 and has been red ever since — through every Renovate PR, which is why none of them landed.

Regenerating the snapshot would buy until 1 January 2027. Normalising the year out of it fixes the problem once. Everything else in the file is still asserted verbatim; only `Copyright (c) <year>` becomes a placeholder, and the normalisation is a no-op for the JSON templates that go through the same branch.

`npm run check` and `npm test` both pass locally: 32 tests, 32 snapshots.