### PR TITLE
Stamp the release action into generated repos

### DIFF
--- a/__tests__/__snapshots__/app.js.snap
+++ b/__tests__/__snapshots__/app.js.snap
@@ -49,14 +49,37 @@ module.exports = {
 "
 `;
 
+exports[`creates .github/release.yml 1`] = `
+"# Categories for GitHub's generated release notes, keyed by the same labels the
+# release reads to derive the semver bump. \`safe to test\` authorises CI runs and
+# says nothing about the release, so it is excluded from both.
+changelog:
+  exclude:
+    labels:
+      - safe to test
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Enhancements
+      labels:
+        - enhancement
+    - title: 🛠 Everything Else
+      labels:
+        - '*'
+"
+`;
+
 exports[`creates .github/workflows/ci.yml 1`] = `
 "name: CI
 
+# \`on:\` does not evaluate expressions, so a branch filter has to name a branch
+# rather than read the repository's default. GitHub creates new repos on main.
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   ci:
@@ -69,6 +92,53 @@ jobs:
       - run: npm ci
       - run: npm test
       - uses: codecov/codecov-action@v4
+"
+`;
+
+exports[`creates .github/workflows/release.yml 1`] = `
+"name: Release
+
+# The filename is load-bearing: npm's trusted publisher for this package
+# matches on repo + workflow filename, so renaming this file means updating the
+# publisher first.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+
+concurrency:
+  group: \${{ github.workflow }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # The cron only ever fires on the default branch, but a manual dispatch can
+    # target any branch. Without this guard, dispatching against a version
+    # branch would bump, tag and publish that branch to npm as latest.
+    if: github.ref_name == github.event.repository.default_branch
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      # Load-bearing: npm publish runs prepublishOnly, whose build needs
+      # node_modules, and the tests gate the release.
+      - run: npm ci
+
+      - run: npm test
+
+      - uses: tanem/release-action@29ffc8b4e3956c1b9532bfb2ad863f31953354a4 # v0.1.0
 "
 `;
 
@@ -346,7 +416,6 @@ exports[`creates package.json 1`] = `
     "rollup-plugin-sourcemaps": Any<String>,
     "rollup-plugin-terser": Any<String>,
     "shx": Any<String>,
-    "tanem-scripts": Any<String>,
     "ts-jest": Any<String>,
     "typescript": Any<String>,
   },
@@ -385,7 +454,7 @@ exports[`creates package.json 1`] = `
     "format": "prettier --write "**/*.{js,ts,tsx}"",
     "lint": "eslint . --ext .js,.ts",
     "postbundle": "npm run clean:compiled && shx cp ./index.js ./dist/index.js",
-    "release": "tanem-scripts release",
+    "prepublishOnly": "npm run build",
     "test": "run-s check:* lint build test:*",
     "test:cjs": "jest --config ./scripts/jest/config.cjs.js",
     "test:cjsprod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.cjs.js",

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -77,3 +77,64 @@ test.each(getFiles())('creates %s', (file) => {
     expect(normaliseYear(readFile(file))).toMatchSnapshot()
   }
 })
+
+// The snapshots above would catch a change to any of the following, but they
+// record it rather than assert it: a reviewer approving an updated snapshot has
+// no way to see which lines were load-bearing. These say so out loud.
+describe('the generated release setup', () => {
+  // A manual dispatch can target any branch. Without the guard, dispatching
+  // against a version branch bumps, tags and publishes that branch to npm as
+  // latest. The pilot repo lost this in migration and had to have it restored.
+  test('guards the release job against a non-default branch', () => {
+    expect(readFile('.github/workflows/release.yml')).toContain(
+      'if: github.ref_name == github.event.repository.default_branch',
+    )
+  })
+
+  test('pins the action to a full commit SHA', () => {
+    expect(readFile('.github/workflows/release.yml')).toMatch(
+      /uses: tanem\/release-action@[0-9a-f]{40} # v\d+\.\d+\.\d+$/m,
+    )
+  })
+
+  // npm publish runs the package's build, which needs node_modules, and the
+  // test run is the gate the release gets to pass through.
+  test('installs and tests before releasing', () => {
+    const workflow = readFile('.github/workflows/release.yml')
+    expect(workflow.indexOf('- run: npm ci')).toBeLessThan(
+      workflow.indexOf('- run: npm test'),
+    )
+    expect(workflow.indexOf('- run: npm test')).toBeLessThan(
+      workflow.indexOf('uses: tanem/release-action@'),
+    )
+  })
+
+  test('categorises generated release notes by the labels the bump reads', () => {
+    const categories = readFile('.github/release.yml')
+    expect(categories).toContain('- breaking')
+    expect(categories).toContain('- enhancement')
+  })
+
+  // GitHub creates new repos on main. A workflow naming a branch the repo does
+  // not have never runs, and does so silently and forever.
+  test.each(['.github/workflows/release.yml', '.github/workflows/ci.yml'])(
+    '%s names no branch a fresh repo will not have',
+    (workflow) => {
+      expect(readFile(workflow)).not.toContain('master')
+    },
+  )
+
+  // Without this, dist/ exists at publish time only because `npm test` happens
+  // to run build before the tests that consume it, and reordering test would
+  // ship an empty tarball with nothing to catch it.
+  test('builds the package as part of publishing it', () => {
+    const { scripts } = readFile('package.json')
+    expect(scripts.prepublishOnly).toBe('npm run build')
+  })
+
+  test('leaves no tanem-scripts wiring in the package manifest', () => {
+    const { devDependencies, scripts } = readFile('package.json')
+    expect(devDependencies).not.toHaveProperty('tanem-scripts')
+    expect(Object.values(scripts).join('\n')).not.toContain('tanem-scripts')
+  })
+})

--- a/generators/app/templates/.github/release.yml
+++ b/generators/app/templates/.github/release.yml
@@ -1,0 +1,17 @@
+# Categories for GitHub's generated release notes, keyed by the same labels the
+# release reads to derive the semver bump. `safe to test` authorises CI runs and
+# says nothing about the release, so it is excluded from both.
+changelog:
+  exclude:
+    labels:
+      - safe to test
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Enhancements
+      labels:
+        - enhancement
+    - title: 🛠 Everything Else
+      labels:
+        - '*'

--- a/generators/app/templates/.github/workflows/ci.yml
+++ b/generators/app/templates/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
+# `on:` does not evaluate expressions, so a branch filter has to name a branch
+# rather than read the repository's default. GitHub creates new repos on main.
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   ci:

--- a/generators/app/templates/.github/workflows/release.yml
+++ b/generators/app/templates/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+# The filename is load-bearing: npm's trusted publisher for this package
+# matches on repo + workflow filename, so renaming this file means updating the
+# publisher first.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # The cron only ever fires on the default branch, but a manual dispatch can
+    # target any branch. Without this guard, dispatching against a version
+    # branch would bump, tag and publish that branch to npm as latest.
+    if: github.ref_name == github.event.repository.default_branch
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      # Load-bearing: npm publish runs prepublishOnly, whose build needs
+      # node_modules, and the tests gate the release.
+      - run: npm ci
+
+      - run: npm test
+
+      - uses: tanem/release-action@29ffc8b4e3956c1b9532bfb2ad863f31953354a4 # v0.1.0

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write \"**/*.{js,ts,tsx}\"",
     "lint": "eslint . --ext .js,.ts",
     "postbundle": "npm run clean:compiled && shx cp ./index.js ./dist/index.js",
-    "release": "tanem-scripts release",
+    "prepublishOnly": "npm run build",
     "test": "run-s check:* lint build test:*",
     "test:cjs": "jest --config ./scripts/jest/config.cjs.js",
     "test:cjsprod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.cjs.js",
@@ -94,7 +94,6 @@
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-terser": "7.0.2",
     "shx": "0.3.3",
-    "tanem-scripts": "7.0.0",
     "ts-jest": "27.0.3",
     "typescript": "4.3.5"
   }


### PR DESCRIPTION
Generated projects are now born on the `tanem/release-action` composite action rather than the `tanem-scripts` package, so a freshly generated repo needs no release edits before its first automated release beyond setting up its own npm trusted publisher.

The new `release.yml` template carries the shape the fleet migration proved: the weekly Monday cron plus manual dispatch, `contents: write` + `id-token: write` + `pull-requests: read`, a workflow-scoped concurrency group, the default-branch guard, full-history checkout, `npm ci`, `npm test`, then the SHA-pinned action. It is byte-identical to the pilot repo's live workflow apart from one comment. Generated repos also get the `.github/release.yml` category file, keyed by the same labels the semver bump reads.

The guard reads the default branch rather than naming one. That distinction is load-bearing here in a way it is not in a hand-written workflow: this is a template, GitHub creates new repos on `main`, and a literal branch name a repo does not have would skip every release silently and forever. The CI workflow template had exactly that bug already baked in as `branches: [master]`, so a generated repo ran no CI at all. Branch filters cannot read the default branch — `on:` does not evaluate expressions — so `ci.yml` now names `main` explicitly, with a comment saying why the guard's approach is unavailable there.

The `tanem-scripts` devDependency and the `release` script it backed are gone from the generated manifest. Publishing now goes through a real `prepublishOnly` instead of relying on `npm test` having happened to run `build` before its dist-consuming tests, so the published tarball's contents no longer depend on the ordering of the test script.

The suite here is snapshot-only, which records a change rather than asserting it — a reviewer approving an updated snapshot has no way to see which lines were load-bearing. Eight explicit tests now sit alongside the snapshots for the invariants that have already regressed once elsewhere or would fail silently: the guard, the SHA pin, `npm ci` before `npm test` before the action, the label categories, the absence of any `tanem-scripts` wiring, and that neither workflow names a branch a fresh repo will not have.

Deliberately left alone: the generated `ci.yml` still floats its action refs at `@v4` and pins `node-version: '14'`, so the two generated workflows now disagree on pinning style. Modernising that template is a separate piece of work.